### PR TITLE
remove additional python setup step in CI; fix shell path causing GHA runner to miss CBC binaries

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,17 +17,30 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    defaults:
+      run:
+        shell: bash -l {0}
+
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - name: Set up conda
+      uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: "3.10"
+        miniforge-variant: Mambaforge # mamba is faster than base conda
+        miniforge-version: latest
+        activate-environment: osier-env
+        use-mamba: true
+        use-only-tar-bz2: true
+    - run: |
+        conda config --env --set pip_interop_enabled True
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Install CBC
+      run: |
+        mamba install coincbc
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -55,7 +55,6 @@ def test_dispatch_model_initialize(technology_set, net_demand):
     assert len(model.indices) == len(net_demand) * len(technology_set)
 
 
-@pytest.mark.skip("Does not work with CI, yet. Requires CBC or CPLEX.")
 def test_dispatch_model_solve(technology_set, net_demand):
     model = DispatchModel(technology_set,
                           net_demand=net_demand,


### PR DESCRIPTION
This PR fixes the issue where the GHA runner can't find the binaries for CBC 